### PR TITLE
DB configuration yml에서 분리 후 별도 설정으로 추가

### DIFF
--- a/src/main/java/com/pro/WOLmgr/configuration/DatabaseConfiguration.java
+++ b/src/main/java/com/pro/WOLmgr/configuration/DatabaseConfiguration.java
@@ -1,0 +1,28 @@
+package com.pro.WOLmgr.configuration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+@Configuration
+@PropertySource("classpath:application.yml")
+public class DatabaseConfiguration {
+
+    @Autowired
+    private Environment env;
+
+    @Bean
+    public DataSource dataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName(env.getProperty("db.driverClassName"));
+        dataSource.setUrl(env.getProperty("db.url"));
+        dataSource.setUsername(env.getProperty("db.username"));
+        dataSource.setPassword(env.getProperty("db.password"));
+        return dataSource;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,11 +2,6 @@ server:
     port: 8080
 
 spring:
-    datasource:
-        driver-class-name: "com.mysql.cj.jdbc.Driver"
-        url: "jdbc:mysql://localhost:3306/qwe?serverTimezone=Asia/Seoul"
-        username: "root"
-        password: "0000"
     jpa:
         # JPA가 수행하는 SQL을 볼 수 있다.
         show-sql: true


### PR DESCRIPTION
## 무엇이 문제인가요?
DB 연결정보가 소스코드에 그대로 노출 됩니다.
## 어떻게 해결했나요?
하드코딩 될 수 밖에 없는 yml파일에 해당 정보를 지우고 별도 java class에서 연결하도록 했습니다.
일단 환경변수에 DB를 등록하도록 했지만 추후에 변경될 수 도 있습니다.
## 어떻게 테스트 했나요?
윈도우에 mysql 설치 후 관련 정보 환경 변수에 작성 후 실행
에러 없이 잘 실행됨