### PR TITLE
DBConfig 수정입니다.

### DIFF
--- a/src/main/java/com/pro/WOLmgr/configuration/DatabaseConfiguration.java
+++ b/src/main/java/com/pro/WOLmgr/configuration/DatabaseConfiguration.java
@@ -14,9 +14,7 @@ import javax.sql.DataSource;
 @PropertySource("classpath:application.yml")
 @RequiredArgsConstructor
 public class DatabaseConfiguration {
-
-    private Environment env;
-
+    private final Environment env;
     @Bean
     public DataSource dataSource() {
         DriverManagerDataSource dataSource = new DriverManagerDataSource();

--- a/src/main/java/com/pro/WOLmgr/configuration/DatabaseConfiguration.java
+++ b/src/main/java/com/pro/WOLmgr/configuration/DatabaseConfiguration.java
@@ -1,5 +1,6 @@
 package com.pro.WOLmgr.configuration;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,9 +12,9 @@ import javax.sql.DataSource;
 
 @Configuration
 @PropertySource("classpath:application.yml")
+@RequiredArgsConstructor
 public class DatabaseConfiguration {
 
-    @Autowired
     private Environment env;
 
     @Bean


### PR DESCRIPTION
# Pr 종류
- [ ] task (개발)
- [x] bugfix (버그 수정)
- [ ] etc (그 외)

# 무엇이 문제인가요? (What)
직접적으로` @Autowired` 어노테이션을 활용하는 것은 의존성을 증가시킬 위험이 있습니다,

# 어떻게 해결하고 구현했나요? (How)
롬복의 @RequiredArgsConstructor 를 사용하여 private final Environment env로 수정하면 final 생성자가 생성됩니다.

```
    private final Environment env;
    
    @Autowired
    public DatabaseConfiguration(Environment env) {
        this.env = env;
    }
```
와 같이 사용할 수 있게 됩니다. 
스프링 5.0이상 버전부터는 생성자에 @Autowired를 생락하여도 의존성 주입을 해주기 때문에 private final Environment env 로 수정하고 @Autowired를 제거하고  @RequiredArgsConstructor를 사용하면 의존성을 줄일 수 있습니다.

# 테스트 했나요?
- [x] Local Test (본인 pc 에서 테스트)
- [ ] include Test Code (테스트 코드 포함)
